### PR TITLE
Updating Readme.adoc from Austin's feedback in test plan

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -192,7 +192,7 @@ include::finish/src/main/java/io/openliberty/guides/system/SystemReadinessCheck.
 ifndef::cloud-hosted[]
 The [hotspot=Readiness file=0]`@Readiness` annotation indicates that this particular bean is a readiness health check procedure.
 By pairing this annotation with the [hotspot=ApplicationScoped]`ApplicationScoped` context from the Contexts and
-Dependency Injections API, the bean is discovered automatically when the http://localhost:9080/health[http://localhost:9080/health^]
+Dependency Injections API, the bean is discovered automatically when the `\http://localhost:9080/health`
 endpoint receives a request.
 endif::[]
 

--- a/README.adoc
+++ b/README.adoc
@@ -201,11 +201,7 @@ ifdef::cloud-hosted[]
 The **@Readiness** annotation indicates that this particular bean is a readiness health check procedure.
 By pairing this annotation with the **ApplicationScoped** context from the Contexts and
 Dependency Injections API, the bean is discovered automatically when the http://localhost:9080/health
-endpoint receives a request. Run the following curl command:
-```
-curl http://localhost:9080/health
-```
-{: codeblock}
+endpoint receives a request.
 endif::[]
 
 


### PR DESCRIPTION
@AustinSeto's feedback can be found [here](https://ibm.ent.box.com/notes/760734518288) and he mentioned that this curl command is not needed. It is just explanation text. @AustinSeto  could you please verify that I have removed the right curl command.

P.S - I am leaving the instruction as a macro so that the guide Converter does not create the curl command again.