### PR TITLE
Update to MP6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -14,8 +14,8 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <!-- Liberty configuration -->
-    <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-    <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+    <liberty.var.http.port>9080</liberty.var.http.port>
+    <liberty.var.https.port>9443</liberty.var.https.port>
   </properties>
 
   <dependencies>
@@ -39,19 +39,19 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.9.2</version>
+      <version>5.10.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
-      <version>6.2.3.Final</version>
+      <version>6.2.7.Final</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-json-binding-provider</artifactId>
-      <version>6.2.3.Final</version>
+      <version>6.2.7.Final</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.12.0</version>
+      <version>3.14.0</version>
     </dependency>
   </dependencies>
 
@@ -80,23 +80,23 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.2.5</version>
       </plugin>
       <!-- Enable liberty-maven plugin -->
       <plugin>
         <groupId>io.openliberty.tools</groupId>
         <artifactId>liberty-maven-plugin</artifactId>
-        <version>3.8.2</version>
+        <version>3.10</version>
       </plugin>
       <!-- Plugin to run functional tests -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.2.5</version>
         <configuration>
           <systemPropertyVariables>
-            <default.http.port>${liberty.var.default.http.port}</default.http.port>
-            <default.https.port>${liberty.var.default.https.port}</default.https.port>
+            <http.port>${liberty.var.http.port}</http.port>
+            <https.port>${liberty.var.https.port}</https.port>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/finish/src/main/liberty/config/server.xml
+++ b/finish/src/main/liberty/config/server.xml
@@ -5,18 +5,18 @@
     <feature>jsonb-3.0</feature>
     <feature>jsonp-2.1</feature>
     <feature>cdi-4.0</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
     <feature>mpRestClient-3.0</feature>
     <!-- tag::mpHealth[] -->
     <feature>mpHealth-4.0</feature>
     <!-- end::mpHealth[] -->
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9080"/>
+  <variable name="https.port" defaultValue="9443"/>
 
-  <httpEndpoint host="*" httpPort="${default.http.port}"
-    httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+  <httpEndpoint host="*" httpPort="${http.port}"
+    httpsPort="${https.port}" id="defaultHttpEndpoint"/>
 
   <webApplication location="guide-microprofile-health.war" contextRoot="/"/>
 </server>

--- a/finish/src/main/webapp/index.html
+++ b/finish/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 ​
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,11 +30,11 @@
     <p>
         For more information about the features used in this application, see the Open Liberty documentation:
         <ul>
-            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Processing 2.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Jakarta Contexts and Dependency Injection 4.0</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#mpRestClient-3.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Rest Client 3.0</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#mpHealth-4.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Health 4.0</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonb-3.0.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Binding 3.0</a></li>

--- a/finish/src/test/java/it/io/openliberty/guides/health/HealthITUtil.java
+++ b/finish/src/test/java/it/io/openliberty/guides/health/HealthITUtil.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -36,7 +36,7 @@ public class HealthITUtil {
                                                   +  "inMaintenance\":true";
 
   static {
-    port = System.getProperty("default.http.port");
+    port = System.getProperty("http.port");
     baseUrl = "http://localhost:" + port + "/";
   }
 

--- a/finish/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
+++ b/finish/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -43,7 +43,7 @@ public class InventoryEndpointIT {
 
   @BeforeAll
   public static void oneTimeSetup() {
-    port = System.getProperty("default.http.port");
+    port = System.getProperty("http.port");
     baseUrl = "http://localhost:" + port + "/";
   }
 

--- a/finish/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
+++ b/finish/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -25,7 +25,7 @@ public class SystemEndpointIT {
 
   @Test
   public void testGetProperties() {
-    String port = System.getProperty("default.http.port");
+    String port = System.getProperty("http.port");
     String url = "http://localhost:" + port + "/";
 
     Client client = ClientBuilder.newClient();

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -14,8 +14,8 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <!-- Liberty configuration -->
-    <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-    <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+    <liberty.var.http.port>9080</liberty.var.http.port>
+    <liberty.var.https.port>9443</liberty.var.https.port>
   </properties>
 
   <dependencies>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile</groupId>
       <artifactId>microprofile</artifactId>
-      <version>6.0</version>
+      <version>6.1</version>
       <type>pom</type>
       <scope>provided</scope>
     </dependency>
@@ -37,19 +37,19 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.9.2</version>
+      <version>5.10.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
-      <version>6.2.3.Final</version>
+      <version>6.2.7.Final</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-json-binding-provider</artifactId>
-      <version>6.2.3.Final</version>
+      <version>6.2.7.Final</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.12.0</version>
+      <version>3.14.0</version>
     </dependency>
   </dependencies>
 
@@ -78,23 +78,23 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.2.5</version>
       </plugin>
       <!-- Enable liberty-maven plugin -->
       <plugin>
         <groupId>io.openliberty.tools</groupId>
         <artifactId>liberty-maven-plugin</artifactId>
-        <version>3.8.2</version>
+        <version>3.10</version>
       </plugin>
       <!-- Plugin to run functional tests -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.2.5</version>
         <configuration>
           <systemPropertyVariables>
-            <default.http.port>${liberty.var.default.http.port}</default.http.port>
-            <default.https.port>${liberty.var.default.https.port}</default.https.port>
+            <http.port>${liberty.var.http.port}</http.port>
+            <https.port>${liberty.var.https.port}</https.port>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/start/src/main/liberty/config/server.xml
+++ b/start/src/main/liberty/config/server.xml
@@ -5,16 +5,16 @@
     <feature>jsonb-3.0</feature>
     <feature>jsonp-2.1</feature>
     <feature>cdi-4.0</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
     <feature>mpRestClient-3.0</feature>
     <feature>mpHealth-4.0</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9080"/>
+  <variable name="https.port" defaultValue="9443"/>
 
-  <httpEndpoint host="*" httpPort="${default.http.port}"
-    httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+  <httpEndpoint host="*" httpPort="${http.port}"
+    httpsPort="${https.port}" id="defaultHttpEndpoint"/>
 
   <webApplication location="guide-microprofile-health.war" contextRoot="/"/>
 </server>

--- a/start/src/main/webapp/index.html
+++ b/start/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 ​
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,11 +30,11 @@
     <p>
         For more information about the features used in this application, see the Open Liberty documentation:
         <ul>
-            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Processing 2.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Jakarta Contexts and Dependency Injection 4.0</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#mpRestClient-3.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Rest Client 3.0</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#mpHealth-4.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Health 4.0</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonb-3.0.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Binding 3.0</a></li>

--- a/start/src/test/java/it/io/openliberty/guides/health/HealthITUtil.java
+++ b/start/src/test/java/it/io/openliberty/guides/health/HealthITUtil.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -36,7 +36,7 @@ public class HealthITUtil {
   "io_openliberty_guides_inventory_inMaintenance\":true";
 
   static {
-    port = System.getProperty("default.http.port");
+    port = System.getProperty("http.port");
     baseUrl = "http://localhost:" + port + "/";
   }
 

--- a/start/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
+++ b/start/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -44,7 +44,7 @@ public class InventoryEndpointIT {
 
   @BeforeAll
   public static void oneTimeSetup() {
-    port = System.getProperty("default.http.port");
+    port = System.getProperty("http.port");
     baseUrl = "http://localhost:" + port + "/";
   }
 

--- a/start/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
+++ b/start/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -25,7 +25,7 @@ public class SystemEndpointIT {
 
   @Test
   public void testGetProperties() {
-    String port = System.getProperty("default.http.port");
+    String port = System.getProperty("http.port");
     String url = "http://localhost:" + port + "/";
 
     Client client = ClientBuilder.newClient();


### PR DESCRIPTION
address issue: https://github.com/OpenLiberty/guides-common/issues/1021

### Review changes
- [ ] pom.xml
  - microfile-profile is 6.1, and dependencies
  - LMP 3.10
  - `default.` should be removed
  - ports `9090`,`9453`,`9091`,`9454` if guide uses local kube
- [ ] server.xml
  - feature version
- [ ] index.html
  - feature version
- [ ] update lgdev with `version-update-mp61` branch
- [ ] do end-to-end test and review content carefully
  - clone the `version-update-mp61` branch
  - if index.html has changes, make sure the links work

